### PR TITLE
Add RDP/Guac security parameter support

### DIFF
--- a/src/app/remote-desktop-manager.service.ts
+++ b/src/app/remote-desktop-manager.service.ts
@@ -264,9 +264,15 @@ export class RemoteDesktopManager {
    */
   private buildParameters(parameters = {}): string {
     const params = new URLSearchParams();
+    var _key;
     for (const key in parameters) {
+      if (typeof key === "string") {
+        _key = key.replace(/_/, '-');
+      } else {
+        _key = key;
+      }
       if (parameters.hasOwnProperty(key)) {
-        params.set(key, parameters[key]);
+        params.set(_key, parameters[key]);
       }
     }
     return params.toString();

--- a/src/app/remote-desktop-viewer/remote-desktop-viewer.component.ts
+++ b/src/app/remote-desktop-viewer/remote-desktop-viewer.component.ts
@@ -74,7 +74,10 @@ export class RemoteDesktopViewerComponent implements OnInit {
 
   handleConnect() {
     const parameters = {
-      hostname: environment.servers.guacamole.integrated_remote_desktop_viewer.cluster_url,
+      hostname:     environment.servers.guacamole.integrated_remote_desktop_viewer.cluster_url,
+      security:     environment.servers.guacamole.integrated_remote_desktop_viewer.security,
+      ignore_cert:  environment.servers.guacamole.integrated_remote_desktop_viewer.ignore_cert,
+      disable_auth: environment.servers.guacamole.integrated_remote_desktop_viewer.disable_auth,
       port: this.route.snapshot.paramMap.get('port'),
       image: 'image/png',
       audio: 'audio/L16',

--- a/src/environments/environment.prod.ts.example
+++ b/src/environments/environment.prod.ts.example
@@ -9,7 +9,10 @@ export const environment = {
       integrated_remote_desktop_viewer : {
         enabled : false, // if true, the guacamole.url will be ignored as it isn't needed
         cluster_url : 'kubernetes-cluster.example.com', // the server or cluster which contains all of the docker/kubernetes containers
-        websocket_server : 'ws://java-server.example.com:8080/ws'
+        websocket_server : 'ws://java-server.example.com:8080/ws',
+        security : 'tls',  // one of: rdp, nla, tls, any.
+        ignore_cert: true,
+        disable_auth: false
       },
       url: 'https://calipsofrontend.domain.tld/gacces/'
     },


### PR DESCRIPTION
Allow the user to specify the following security-based
parameters in the environment.ts file for *RDP* connections.

  - security     (rdp, nla, tls, any)
  - ignore_cert  (boolean; self-explanatory)
  - disable_auth (boolean; disable authentication)

It can be necessary to tweak these, depending on
the RDP server listening.

NOTE: the buildParameters() trivial search/replace should be
scrutinised, as I use a throwaway var for re-indexing the dict.
This is search/replace is necessary, as the URL-encoded params
take hypenated verbs, but this is obviously not allowed in code,
hence the '_' -> '-' munge.  Also, if these vars are not present in
the environment.ts file, the project will not build, as we explicitly
define them in the code.