### PR TITLE
Add useroffice URL environment params, remove hardcoded ALBA URL

### DIFF
--- a/src/app/authentication.service.ts
+++ b/src/app/authentication.service.ts
@@ -18,7 +18,7 @@ export class AuthenticationService {
   umbrellaLogoutUrl = this.backendUrl_calipso + 'umbrella/logout/';
   logoutUrl = this.backendUrl_calipso + 'logout/';
   userUrl = this.backendUrl_calipso + 'user/$USERNAME/';
-  UOWebUrl = 'https://useroffice.cells.es/Welcome';
+  UOWebUrl = environment.auth.useroffice.url;
 
 
   constructor(private http: HttpClient, private router: Router) { }

--- a/src/environments/environment.docker.ts.example
+++ b/src/environments/environment.docker.ts.example
@@ -2,30 +2,30 @@ export const environment = {
   production: false,
   servers: {
     api: {
-      url: "/",
-      basehref: "services/"
+      url: '/',
+      basehref: 'services/'
     },
     guacamole: {
-      url: "/guac/"
+      url: '/guac/'
     },
     jupyterhub: {
       enabled: false,
-      url: "http://jupyter.example.com"
+      url: 'http://jupyter.example.com'
     }
   },
   auth: {
     oidc: {
       enabled: false,
-      url: "http://example.com/oidc/authenticate"
+      url: 'http://example.com/oidc/authenticate'
     },
     useroffice: {
       enabled: true,
-      url: "https://USEROFFICE.URL"
+      url: 'https://USEROFFICE.URL'
     }
   },
   frontend: {
-    url: "http://web-front/",
-    facilityLogo: "assets/images/insert-logo-here.jpg"
+    url: 'http://web-front/',
+    facilityLogo: 'assets/images/insert-logo-here.jpg'
   },
-  env: "docker"
+  env: 'docker'
 };

--- a/src/environments/environment.docker.ts.example
+++ b/src/environments/environment.docker.ts.example
@@ -17,7 +17,7 @@ export const environment = {
     oidc: {
       enabled: false,
       url: 'http://example.com/oidc/authenticate'
-    }
+    },
 	 useroffice: {
       enabled: true,
       url: 'https://USEROFFICE.URL'

--- a/src/environments/environment.docker.ts.example
+++ b/src/environments/environment.docker.ts.example
@@ -2,30 +2,30 @@ export const environment = {
   production: false,
   servers: {
     api: {
-      url: '/',
-      basehref: 'services/'
+      url: "/",
+      basehref: "services/"
     },
     guacamole: {
-      url: '/guac/'
+      url: "/guac/"
     },
     jupyterhub: {
       enabled: false,
-      url: 'http://jupyter.example.com'
+      url: "http://jupyter.example.com"
     }
   },
   auth: {
     oidc: {
       enabled: false,
-      url: 'http://example.com/oidc/authenticate'
+      url: "http://example.com/oidc/authenticate"
     },
-	  useroffice: {
+    useroffice: {
       enabled: true,
-      url: 'https://USEROFFICE.URL'
-   }
+      url: "https://USEROFFICE.URL"
+    }
   },
   frontend: {
-    url: 'http://web-front/',
-    facilityLogo: 'assets/images/insert-logo-here.jpg'
+    url: "http://web-front/",
+    facilityLogo: "assets/images/insert-logo-here.jpg"
   },
-  env : 'docker'
+  env: "docker"
 };

--- a/src/environments/environment.docker.ts.example
+++ b/src/environments/environment.docker.ts.example
@@ -18,6 +18,10 @@ export const environment = {
       enabled: false,
       url: 'http://example.com/oidc/authenticate'
     }
+	 useroffice: {
+      enabled: true,
+      url: 'https://USEROFFICE.URL'
+   }
   },
   frontend: {
     url: 'http://web-front/',

--- a/src/environments/environment.docker.ts.example
+++ b/src/environments/environment.docker.ts.example
@@ -18,7 +18,7 @@ export const environment = {
       enabled: false,
       url: 'http://example.com/oidc/authenticate'
     },
-	 useroffice: {
+	  useroffice: {
       enabled: true,
       url: 'https://USEROFFICE.URL'
    }

--- a/src/environments/environment.prod.ts.example
+++ b/src/environments/environment.prod.ts.example
@@ -17,7 +17,11 @@ export const environment = {
     oidc: {
       enabled: false,
       url: 'http://example.com/oidc/authenticate'
-    }
+    },
+    useroffice: {
+      enabled: true,
+      url: 'https://USEROFFICE.URL'
+   }
   },
   frontend: {
     url: 'https://calipsofrontend.domain.tld/',

--- a/src/environments/environment.ts.example
+++ b/src/environments/environment.ts.example
@@ -22,8 +22,8 @@ export const environment = {
     oidc: {
       enabled: false,
       url: 'http://example.com/oidc/authenticate'
-    }
-	useroffice: {
+    },
+	  useroffice: {
       enabled: true,
       url: 'https://USEROFFICE.URL'
    }

--- a/src/environments/environment.ts.example
+++ b/src/environments/environment.ts.example
@@ -23,6 +23,10 @@ export const environment = {
       enabled: false,
       url: 'http://example.com/oidc/authenticate'
     }
+	useroffice: {
+      enabled: true,
+      url: 'https://USEROFFICE.URL'
+   }
   },
   frontend: {
     url: 'http://calipso-frontend/',


### PR DESCRIPTION
As per a discussion with Aidan and Alex, we are
removing the hardcoded UOWebUrl (previously set
to 'https://useroffice.cells.es/Welcome') and
allowing this to be configurable via the frontend
environment.ts files.

The README will also need to be updated.

Currently, the 'enabled' boolean doesn't do anything.