### PR TITLE
Fix user URL naming issue

### DIFF
--- a/src/app/authentication.service.ts
+++ b/src/app/authentication.service.ts
@@ -17,7 +17,7 @@ export class AuthenticationService {
   uoUserFromHashUrl = this.backendUrl_calipso + 'umbrella/wuo/';
   umbrellaLogoutUrl = this.backendUrl_calipso + 'umbrella/logout/';
   logoutUrl = this.backendUrl_calipso + 'logout/';
-  userUrl = this.backendUrl_calipso + 'user/$USERNAME/';
+  userUrl = this.backendUrl_calipso + 'users/$USERNAME/';
   UOWebUrl = environment.auth.useroffice.url;
 
   constructor(private http: HttpClient, private router: Router) { }


### PR DESCRIPTION
Commit 37d096a70f944 introduced a regression
where "users" was renamed to "user". This
inadvertently clobbered a previous commit
from Aidan (f2e9164e979a4)